### PR TITLE
Added FreeBSD support, basic documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptracer"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Bostjan Vesnicer <bostjan.vesnicer@gmail.com>",
     "Simon Wörner <git@simon-woerner.de>"
@@ -12,8 +12,13 @@ repository = "https://github.com/SWW13/ptracer"
 license = "MIT"
 
 [dependencies]
-nix = "^0.15"
+libc = "^0.2.72"
+nix = "^0.17"
+cfg-if = "^0.1"
 log = "^0.4"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = "^0.7"
 
 [dev-dependencies]
 goblin = { version = "^0.1.3", default_features=false, features=["std", "endian_fd", "elf32", "elf64"]}

--- a/examples/verbose.rs
+++ b/examples/verbose.rs
@@ -1,5 +1,6 @@
-use nix::{sys::ptrace, sys::wait::WaitStatus};
-use ptracer::{util, ContinueMode, Ptracer, ThreadState};
+use nix::sys::wait::WaitStatus;
+use ptracer::util;
+use ptracer::{ContinueMode, Ptracer, Registers};
 use std::env;
 use std::fs::File;
 use std::io::Read;
@@ -25,12 +26,13 @@ fn main() {
 
     println!(
         "Process (PID={}) spawned @ RIP={:016x}",
-        ptracer.pid, ptracer.registers.rip
+        ptracer.pid,
+        ptracer.registers.rip()
     );
 
-    let mmaps = util::read_memory_maps(ptracer.pid);
+    let mmaps = util::get_memory_maps(ptracer.pid).unwrap();
 
-    let base_address = mmaps[0].offset;
+    let base_address = mmaps[0].start as usize;
     println!("Base address: {:#018x}", base_address);
 
     let show_bytes = |address, size| {
@@ -67,7 +69,9 @@ fn main() {
     let pid = ptracer.pid;
     println!(
         ">>>>> First breakpoint: RIP={:#018x}, PID={}, Event={:?}",
-        ptracer.registers.rip, pid, event
+        ptracer.registers.rip(),
+        pid,
+        event
     );
 
     ptracer
@@ -90,7 +94,10 @@ fn main() {
             WaitStatus::Stopped(pid, signal) => {
                 println!("Thread (PID={}) received signal {}", pid, signal);
             }
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             WaitStatus::PtraceEvent(pid, _, pevent) => {
+                use nix::sys::ptrace;
+
                 if *pevent == ptrace::Event::PTRACE_EVENT_CLONE as i32 {
                     println!("Thread (PID={}) cloned", pid);
                 } else if *pevent == ptrace::Event::PTRACE_EVENT_FORK as i32
@@ -111,7 +118,9 @@ fn main() {
                     );
                 }
             }
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             WaitStatus::PtraceSyscall(pid) => {
+                use ptracer::ThreadState;
                 print!("Thread (PID={}) PtraceSyscall ", pid);
 
                 if let Some(thread_state) = ptracer.threads.get(pid) {
@@ -139,5 +148,5 @@ fn main() {
         }
     }
 
-    ptracer.detach().unwrap();
+    ptracer.detach(None).unwrap();
 }

--- a/examples/verbose.rs
+++ b/examples/verbose.rs
@@ -26,18 +26,18 @@ fn main() {
 
     println!(
         "Process (PID={}) spawned @ RIP={:016x}",
-        ptracer.pid,
-        ptracer.registers.rip()
+        ptracer.pid(),
+        ptracer.registers().rip()
     );
 
-    let mmaps = util::get_memory_maps(ptracer.pid).unwrap();
+    let mmaps = util::get_memory_maps(ptracer.pid()).unwrap();
 
     let base_address = mmaps[0].start as usize;
     println!("Base address: {:#018x}", base_address);
 
     let show_bytes = |address, size| {
         let mut data = vec![0 as u8; size];
-        util::read_data(ptracer.pid, address, &mut data).unwrap();
+        util::read_data(ptracer.pid(), address, &mut data).unwrap();
         print!("Memory @ {:#018x}:", address);
         for b in &data {
             print!(" {:02x}", b);
@@ -56,7 +56,7 @@ fn main() {
     show_bytes(base_address + entry_offset, 16);
 
     println!();
-    util::show_registers(&ptracer.registers);
+    util::show_registers(ptracer.registers());
     println!();
 
     // Break at entry point
@@ -66,10 +66,10 @@ fn main() {
 
     ptracer.cont(ContinueMode::Default).as_ref().unwrap();
     let event = ptracer.event();
-    let pid = ptracer.pid;
+    let pid = ptracer.pid();
     println!(
         ">>>>> First breakpoint: RIP={:#018x}, PID={}, Event={:?}",
-        ptracer.registers.rip(),
+        ptracer.registers().rip(),
         pid,
         event
     );
@@ -123,7 +123,7 @@ fn main() {
                 use ptracer::ThreadState;
                 print!("Thread (PID={}) PtraceSyscall ", pid);
 
-                if let Some(thread_state) = ptracer.threads.get(pid) {
+                if let Some(thread_state) = ptracer.threads().get(pid) {
                     match *thread_state {
                         ThreadState::SyscallEnter => print!("enter "),
                         ThreadState::SyscallExit => print!("exit "),
@@ -131,9 +131,9 @@ fn main() {
                     }
                 }
 
-                let rip = ptracer.registers.rip;
-                let rax = ptracer.registers.rax;
-                let orig_rax = ptracer.registers.orig_rax;
+                let rip = ptracer.registers().rip();
+                let rax = ptracer.registers().rax();
+                let orig_rax = ptracer.registers().orig_rax;
                 println!(
                     "RIP={:016x}, RAX={:016x}, ORIG_RAX={:016x}",
                     rip, rax, orig_rax

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -1,0 +1,363 @@
+use crate::{
+    util::{MemoryMap, Permissions},
+    Registers,
+};
+use log::debug;
+use nix::libc::{c_char, c_int, c_long, c_void, pid_t, ptrace, size_t, reg};
+use nix::libc::{PT_GETREGS, PT_IO, PT_SETREGS, PT_SYSCALL, PT_VM_ENTRY};
+use nix::sys::ptrace::{AddressType, RequestType};
+use nix::{errno::Errno, sys::signal::Signal, unistd::Pid, Result};
+use std::os::unix::ffi::OsStrExt;
+use std::{cmp, ffi::OsStr, mem, ptr};
+
+pub type PtraceData = u32;
+pub type PtraceRegisters = reg;
+
+const PIOD_READ_D: c_int = 1;
+
+impl Registers for reg {
+    fn r15(&self) -> u64 {
+        self.r_r15 as _
+    }
+    fn r14(&self) -> u64 {
+        self.r_r14 as _
+    }
+    fn r13(&self) -> u64 {
+        self.r_r13 as _
+    }
+    fn r12(&self) -> u64 {
+        self.r_r12 as _
+    }
+    fn rbp(&self) -> u64 {
+        self.r_rbp as _
+    }
+    fn rbx(&self) -> u64 {
+        self.r_rbx as _
+    }
+    fn r11(&self) -> u64 {
+        self.r_r11 as _
+    }
+    fn r10(&self) -> u64 {
+        self.r_r10 as _
+    }
+    fn r9(&self) -> u64 {
+        self.r_r9 as _
+    }
+    fn r8(&self) -> u64 {
+        self.r_r8 as _
+    }
+    fn rax(&self) -> u64 {
+        self.r_rax as _
+    }
+    fn rcx(&self) -> u64 {
+        self.r_rcx as _
+    }
+    fn rdx(&self) -> u64 {
+        self.r_rdx as _
+    }
+    fn rsi(&self) -> u64 {
+        self.r_rsi as _
+    }
+    fn rdi(&self) -> u64 {
+        self.r_rdi as _
+    }
+    fn rip(&self) -> u64 {
+        self.r_rip as _
+    }
+    fn cs(&self) -> u64 {
+        self.r_cs as _
+    }
+    fn rflags(&self) -> u64 {
+        self.r_rflags as _
+    }
+    fn rsp(&self) -> u64 {
+        self.r_rsp as _
+    }
+    fn ss(&self) -> u64 {
+        self.r_ss as _
+    }
+    fn ds(&self) -> u64 {
+        self.r_ds as _
+    }
+    fn es(&self) -> u64 {
+        self.r_es as _
+    }
+    fn fs(&self) -> u64 {
+        self.r_fs as _
+    }
+    fn gs(&self) -> u64 {
+        self.r_gs as _
+    }
+
+    fn set_r15(&mut self, value: u64) {
+        self.r_r15 = value as _;
+    }
+    fn set_r14(&mut self, value: u64) {
+        self.r_r14 = value as _;
+    }
+    fn set_r13(&mut self, value: u64) {
+        self.r_r13 = value as _;
+    }
+    fn set_r12(&mut self, value: u64) {
+        self.r_r12 = value as _;
+    }
+    fn set_rbp(&mut self, value: u64) {
+        self.r_rbp = value as _;
+    }
+    fn set_rbx(&mut self, value: u64) {
+        self.r_rbx = value as _;
+    }
+    fn set_r11(&mut self, value: u64) {
+        self.r_r11 = value as _;
+    }
+    fn set_r10(&mut self, value: u64) {
+        self.r_r10 = value as _;
+    }
+    fn set_r9(&mut self, value: u64) {
+        self.r_r9 = value as _;
+    }
+    fn set_r8(&mut self, value: u64) {
+        self.r_r8 = value as _;
+    }
+    fn set_rax(&mut self, value: u64) {
+        self.r_rax = value as _;
+    }
+    fn set_rcx(&mut self, value: u64) {
+        self.r_rcx = value as _;
+    }
+    fn set_rdx(&mut self, value: u64) {
+        self.r_rdx = value as _;
+    }
+    fn set_rsi(&mut self, value: u64) {
+        self.r_rsi = value as _;
+    }
+    fn set_rdi(&mut self, value: u64) {
+        self.r_rdi = value as _;
+    }
+    fn set_rip(&mut self, value: u64) {
+        self.r_rip = value as _;
+    }
+    fn set_cs(&mut self, value: u64) {
+        self.r_cs = value as _;
+    }
+    fn set_rflags(&mut self, value: u64) {
+        self.r_rflags = value as _;
+    }
+    fn set_rsp(&mut self, value: u64) {
+        self.r_rsp = value as _;
+    }
+    fn set_ss(&mut self, value: u64) {
+        self.r_ss = value as _;
+    }
+    fn set_ds(&mut self, value: u64) {
+        self.r_ds = value as _;
+    }
+    fn set_es(&mut self, value: u64) {
+        self.r_es = value as _;
+    }
+    fn set_fs(&mut self, value: u64) {
+        self.r_fs = value as _;
+    }
+    fn set_gs(&mut self, value: u64) {
+        self.r_gs = value as _;
+    }
+}
+
+pub fn syscall<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
+    let data = match sig.into() {
+        Some(s) => s as c_int,
+        None => 0,
+    };
+    let res = unsafe {
+        // Ignore the useless return value
+        ptrace(PT_SYSCALL, pid_t::from(pid), 1 as AddressType, data)
+    };
+    Errno::result(res).map(drop)
+}
+
+/// Get user registers, as with `ptrace(PT_GETREGS, ...)`
+pub fn getregs(pid: Pid) -> Result<reg> {
+    let mut data = mem::MaybeUninit::uninit();
+    let res = unsafe {
+        ptrace(
+            PT_GETREGS as RequestType,
+            pid_t::from(pid),
+            data.as_mut_ptr() as *mut _,
+            0,
+        )
+    };
+    Errno::result(res)?;
+    Ok(unsafe { data.assume_init() })
+}
+
+/// Set user registers, as with `ptrace(PT_SETREGS, ...)`
+pub fn setregs(pid: Pid, regs: reg) -> Result<()> {
+    let res = unsafe {
+        ptrace(
+            PT_SETREGS as RequestType,
+            pid_t::from(pid),
+            &regs as *const _ as *mut _,
+            0,
+        )
+    };
+    Errno::result(res).map(drop)
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ptrace_io_desc {
+    /// I/O operation
+    pub piod_op: c_int,
+    /// child offset
+    pub piod_offs: *mut c_void,
+    /// parent offset
+    pub piod_addr: *mut c_void,
+    /// request length
+    pub piod_len: size_t,
+}
+
+pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize> {
+    let io_desc = ptrace_io_desc {
+        piod_op: PIOD_READ_D,
+        piod_offs: address as *mut _,
+        piod_addr: data.as_mut_ptr() as *mut _,
+        piod_len: data.len() as _,
+    };
+    log::trace!("io_desc = {:#?}", io_desc);
+    let res = unsafe {
+        ptrace(
+            PT_IO as RequestType,
+            pid_t::from(pid),
+            &io_desc as *const _ as *mut _,
+            0,
+        )
+    };
+    log::trace!("io_desc = {:#?}", io_desc);
+    log::trace!("res = {:#?}", res);
+    Errno::result(res).map(|_| io_desc.piod_len as usize)
+}
+
+// NOTE: ptrace read is broken for some reason, emulate it with io read
+pub fn read(pid: Pid, address: AddressType) -> nix::Result<c_int> {
+    let mut data = [0u8; 4];
+    let size = read_data(pid, address as _, &mut data)?;
+    debug_assert_eq!(size, 4);
+
+    Ok(c_int::from_le_bytes(data))
+}
+
+const FILE_NAME_BUFFER_LENGTH: usize = 4096;
+
+pub const VM_PROT_READ: i32 = 0x01;
+pub const VM_PROT_WRITE: i32 = 0x02;
+pub const VM_PROT_EXECUTE: i32 = 0x04;
+pub const VM_PROT_COPY: i32 = 0x08;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct vm_entry {
+    pub pve_entry: c_int,
+    pub pve_timestamp: c_int,
+    pub pve_start: c_long,
+    pub pve_end: c_long,
+    pub pve_offset: c_long,
+    pub pve_prot: c_int,
+    pub pve_pathlen: c_int,
+    pub pve_fileid: c_long,
+    pub pve_fsid: u32,
+    pub pve_path: *const c_char,
+}
+
+impl Default for vm_entry {
+    fn default() -> Self {
+        Self {
+            pve_entry: 0,
+            pve_timestamp: 0,
+            pve_start: 0,
+            pve_end: 0,
+            pve_offset: 0,
+            pve_prot: 0,
+            pve_pathlen: 0,
+            pve_fileid: 0,
+            pve_fsid: 0,
+            pve_path: ptr::null(),
+        }
+    }
+}
+
+/// Read virtual memory entry with `ptrace(PT_VM_ENTRY, ...)`
+pub fn read_vm_entry(pid: pid_t, vm_entry: &vm_entry) -> nix::Result<()> {
+    let res = unsafe { ptrace(PT_VM_ENTRY, pid, vm_entry as *const _ as *mut _, 0) };
+    Errno::result(res).map(drop)
+}
+
+impl MemoryMap {
+    fn from_vm_entry(entry: &vm_entry, pve_path: &[u8]) -> Self {
+        let pve_path = OsStr::from_bytes(pve_path);
+        let filepath = if pve_path.len() > 0 {
+            Some(pve_path.into())
+        } else {
+            None
+        };
+
+        MemoryMap {
+            start: entry.pve_start as u64,
+            end: entry.pve_end as u64,
+            offset: entry.pve_offset as u64,
+            permissions: Permissions::from(entry.pve_prot),
+            filepath,
+        }
+    }
+}
+
+impl From<c_int> for Permissions {
+    fn from(protection: c_int) -> Self {
+        Permissions {
+            read: protection & VM_PROT_READ != 0,
+            write: protection & VM_PROT_WRITE != 0,
+            execute: protection & VM_PROT_EXECUTE != 0,
+            copy: protection & VM_PROT_COPY != 0,
+        }
+    }
+}
+
+pub fn get_memory_maps(pid: Pid) -> nix::Result<Vec<MemoryMap>> {
+    // By setting pve_pathlen to a non-zero value on entry,
+    // the pathname of the backing object is returned in the buffer pointed to by pve_path,
+    // provided the entry is backed by a vnode.
+    let mut pve_path: Vec<u8> = vec![0; FILE_NAME_BUFFER_LENGTH];
+    let path_ptr = pve_path.as_mut_ptr();
+    let mut entry = vm_entry::default();
+    let mut mmaps = vec![];
+
+    loop {
+        // reset path ptr and len
+        entry.pve_path = path_ptr as *const _;
+        entry.pve_pathlen = FILE_NAME_BUFFER_LENGTH as _;
+
+        match read_vm_entry(pid.as_raw(), &entry) {
+            Ok(_) => {
+                log::trace!("entry = {:#?}", entry);
+
+                // The pve_pathlen field is updated with the actual length of the pathname
+                // (including the terminating null character).
+                mem::forget(pve_path);
+                pve_path = unsafe {
+                    Vec::from_raw_parts(
+                        path_ptr,
+                        cmp::max(0, entry.pve_pathlen - 1) as usize,
+                        FILE_NAME_BUFFER_LENGTH,
+                    )
+                };
+
+                mmaps.push(MemoryMap::from_vm_entry(&entry, &pve_path));
+            }
+            Err(e) => {
+                debug!("read_vm_entry error: {:#x?}", e);
+                break;
+            }
+        }
+    }
+
+    Ok(mmaps)
+}

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -3,7 +3,7 @@ use crate::{
     Registers,
 };
 use log::debug;
-use nix::libc::{c_char, c_int, c_long, c_void, pid_t, ptrace, size_t, reg};
+use nix::libc::{c_char, c_int, c_long, c_void, pid_t, ptrace, reg, size_t};
 use nix::libc::{PT_GETREGS, PT_IO, PT_SETREGS, PT_SYSCALL, PT_VM_ENTRY};
 use nix::sys::ptrace::{AddressType, RequestType};
 use nix::{errno::Errno, sys::signal::Signal, unistd::Pid, Result};
@@ -16,162 +16,208 @@ pub type PtraceRegisters = reg;
 const PIOD_READ_D: c_int = 1;
 
 impl Registers for reg {
+    #[inline]
     fn r15(&self) -> u64 {
         self.r_r15 as _
     }
+    #[inline]
     fn r14(&self) -> u64 {
         self.r_r14 as _
     }
+    #[inline]
     fn r13(&self) -> u64 {
         self.r_r13 as _
     }
+    #[inline]
     fn r12(&self) -> u64 {
         self.r_r12 as _
     }
+    #[inline]
     fn rbp(&self) -> u64 {
         self.r_rbp as _
     }
+    #[inline]
     fn rbx(&self) -> u64 {
         self.r_rbx as _
     }
+    #[inline]
     fn r11(&self) -> u64 {
         self.r_r11 as _
     }
+    #[inline]
     fn r10(&self) -> u64 {
         self.r_r10 as _
     }
+    #[inline]
     fn r9(&self) -> u64 {
         self.r_r9 as _
     }
+    #[inline]
     fn r8(&self) -> u64 {
         self.r_r8 as _
     }
+    #[inline]
     fn rax(&self) -> u64 {
         self.r_rax as _
     }
+    #[inline]
     fn rcx(&self) -> u64 {
         self.r_rcx as _
     }
+    #[inline]
     fn rdx(&self) -> u64 {
         self.r_rdx as _
     }
+    #[inline]
     fn rsi(&self) -> u64 {
         self.r_rsi as _
     }
+    #[inline]
     fn rdi(&self) -> u64 {
         self.r_rdi as _
     }
+    #[inline]
     fn rip(&self) -> u64 {
         self.r_rip as _
     }
+    #[inline]
     fn cs(&self) -> u64 {
         self.r_cs as _
     }
+    #[inline]
     fn rflags(&self) -> u64 {
         self.r_rflags as _
     }
+    #[inline]
     fn rsp(&self) -> u64 {
         self.r_rsp as _
     }
+    #[inline]
     fn ss(&self) -> u64 {
         self.r_ss as _
     }
+    #[inline]
     fn ds(&self) -> u64 {
         self.r_ds as _
     }
+    #[inline]
     fn es(&self) -> u64 {
         self.r_es as _
     }
+    #[inline]
     fn fs(&self) -> u64 {
         self.r_fs as _
     }
+    #[inline]
     fn gs(&self) -> u64 {
         self.r_gs as _
     }
 
+    #[inline]
     fn set_r15(&mut self, value: u64) {
         self.r_r15 = value as _;
     }
+    #[inline]
     fn set_r14(&mut self, value: u64) {
         self.r_r14 = value as _;
     }
+    #[inline]
     fn set_r13(&mut self, value: u64) {
         self.r_r13 = value as _;
     }
+    #[inline]
     fn set_r12(&mut self, value: u64) {
         self.r_r12 = value as _;
     }
+    #[inline]
     fn set_rbp(&mut self, value: u64) {
         self.r_rbp = value as _;
     }
+    #[inline]
     fn set_rbx(&mut self, value: u64) {
         self.r_rbx = value as _;
     }
+    #[inline]
     fn set_r11(&mut self, value: u64) {
         self.r_r11 = value as _;
     }
+    #[inline]
     fn set_r10(&mut self, value: u64) {
         self.r_r10 = value as _;
     }
+    #[inline]
     fn set_r9(&mut self, value: u64) {
         self.r_r9 = value as _;
     }
+    #[inline]
     fn set_r8(&mut self, value: u64) {
         self.r_r8 = value as _;
     }
+    #[inline]
     fn set_rax(&mut self, value: u64) {
         self.r_rax = value as _;
     }
+    #[inline]
     fn set_rcx(&mut self, value: u64) {
         self.r_rcx = value as _;
     }
+    #[inline]
     fn set_rdx(&mut self, value: u64) {
         self.r_rdx = value as _;
     }
+    #[inline]
     fn set_rsi(&mut self, value: u64) {
         self.r_rsi = value as _;
     }
+    #[inline]
     fn set_rdi(&mut self, value: u64) {
         self.r_rdi = value as _;
     }
+    #[inline]
     fn set_rip(&mut self, value: u64) {
         self.r_rip = value as _;
     }
+    #[inline]
     fn set_cs(&mut self, value: u64) {
         self.r_cs = value as _;
     }
+    #[inline]
     fn set_rflags(&mut self, value: u64) {
         self.r_rflags = value as _;
     }
+    #[inline]
     fn set_rsp(&mut self, value: u64) {
         self.r_rsp = value as _;
     }
+    #[inline]
     fn set_ss(&mut self, value: u64) {
         self.r_ss = value as _;
     }
+    #[inline]
     fn set_ds(&mut self, value: u64) {
         self.r_ds = value as _;
     }
+    #[inline]
     fn set_es(&mut self, value: u64) {
         self.r_es = value as _;
     }
+    #[inline]
     fn set_fs(&mut self, value: u64) {
         self.r_fs = value as _;
     }
+    #[inline]
     fn set_gs(&mut self, value: u64) {
         self.r_gs = value as _;
     }
 }
 
+/// Report stops for both system call entry	and exit.
 pub fn syscall<T: Into<Option<Signal>>>(pid: Pid, sig: T) -> Result<()> {
     let data = match sig.into() {
         Some(s) => s as c_int,
         None => 0,
     };
-    let res = unsafe {
-        // Ignore the useless return value
-        ptrace(PT_SYSCALL, pid_t::from(pid), 1 as AddressType, data)
-    };
+    let res = unsafe { ptrace(PT_SYSCALL, pid_t::from(pid), 1 as AddressType, data) };
     Errno::result(res).map(drop)
 }
 
@@ -203,6 +249,7 @@ pub fn setregs(pid: Pid, regs: reg) -> Result<()> {
     Errno::result(res).map(drop)
 }
 
+// TODO: https://github.com/rust-lang/libc/pull/1819
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct ptrace_io_desc {
@@ -216,14 +263,13 @@ pub struct ptrace_io_desc {
     pub piod_len: size_t,
 }
 
-pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize> {
+fn pt_io(pid: Pid, operation: c_int, address: usize, data: &[u8]) -> nix::Result<usize> {
     let io_desc = ptrace_io_desc {
-        piod_op: PIOD_READ_D,
+        piod_op: operation,
         piod_offs: address as *mut _,
-        piod_addr: data.as_mut_ptr() as *mut _,
+        piod_addr: data.as_ptr() as *const _ as *mut _,
         piod_len: data.len() as _,
     };
-    log::trace!("io_desc = {:#?}", io_desc);
     let res = unsafe {
         ptrace(
             PT_IO as RequestType,
@@ -232,27 +278,38 @@ pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize
             0,
         )
     };
-    log::trace!("io_desc = {:#?}", io_desc);
-    log::trace!("res = {:#?}", res);
     Errno::result(res).map(|_| io_desc.piod_len as usize)
 }
 
-// NOTE: ptrace read is broken for some reason, emulate it with io read
+/// Read data from the traced process's address space.
+pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize> {
+    pt_io(pid, PIOD_READ_D as RequestType, address, data)
+}
+
+/// Write data to the traced process's address space.
+pub fn write_data(pid: Pid, address: usize, data: &[u8]) -> nix::Result<usize> {
+    pt_io(pid, PIOD_WRITE_D as RequestType, address, data)
+}
+
+/// Read a single int from the traced process's address space.
 pub fn read(pid: Pid, address: AddressType) -> nix::Result<c_int> {
+    // NOTE: ptrace read is broken for some reason, emulate it with io read
     let mut data = [0u8; 4];
     let size = read_data(pid, address as _, &mut data)?;
     debug_assert_eq!(size, 4);
 
-    Ok(c_int::from_le_bytes(data))
+    Ok(c_int::from_ne_bytes(data))
 }
 
 const FILE_NAME_BUFFER_LENGTH: usize = 4096;
 
+// TODO: https://github.com/rust-lang/libc/pull/1819
 pub const VM_PROT_READ: i32 = 0x01;
 pub const VM_PROT_WRITE: i32 = 0x02;
 pub const VM_PROT_EXECUTE: i32 = 0x04;
 pub const VM_PROT_COPY: i32 = 0x08;
 
+// TODO: https://github.com/rust-lang/libc/pull/1819
 #[repr(C)]
 #[derive(Debug)]
 pub struct vm_entry {
@@ -321,6 +378,7 @@ impl From<c_int> for Permissions {
     }
 }
 
+/// Get memory mappings of process identified by `pid`.
 pub fn get_memory_maps(pid: Pid) -> nix::Result<Vec<MemoryMap>> {
     // By setting pve_pathlen to a non-zero value on entry,
     // the pathname of the backing object is returned in the buffer pointed to by pve_path,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,205 @@
+use crate::{
+    util::{MemoryMap, Permissions},
+    Pid, Registers,
+};
+use procfs::process::{MMapPath, MemoryMap as ProcMMap, Process};
+use procfs::ProcResult;
+
+pub type PtraceData = u64;
+pub type PtraceRegisters = nix::libc::user_regs_struct;
+
+impl From<ProcMMap> for MemoryMap {
+    fn from(mmap: ProcMMap) -> Self {
+        let (start, end) = mmap.address;
+        let filepath = match mmap.pathname {
+            MMapPath::Path(path) => Some(path),
+            _ => None,
+        };
+
+        MemoryMap {
+            start,
+            end,
+            offset: mmap.offset,
+            permissions: Permissions::from(mmap.perms.as_ref()),
+            filepath,
+        }
+    }
+}
+
+impl From<&str> for Permissions {
+    fn from(perms: &str) -> Self {
+        let mut perm = perms.chars();
+        Permissions {
+            read: perm.next() == Some('r'),
+            write: perm.next() == Some('w'),
+            execute: perm.next() == Some('x'),
+            copy: perm.next() == Some('p'),
+        }
+    }
+}
+
+pub fn get_memory_maps(pid: Pid) -> ProcResult<Vec<MemoryMap>> {
+    Ok(Process::new(pid.as_raw())?
+        .maps()?
+        .into_iter()
+        .map(MemoryMap::from)
+        .collect())
+}
+
+pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize> {
+    use nix::sys::uio::{process_vm_readv, IoVec, RemoteIoVec};
+
+    let len = data.len();
+    let local_iov = IoVec::from_mut_slice(data);
+    let remote_iov = RemoteIoVec { base: address, len };
+
+    process_vm_readv(pid, &[local_iov], &[remote_iov])
+}
+
+impl Registers for nix::libc::user_regs_struct {
+    fn r15(&self) -> u64 {
+        self.r15
+    }
+    fn r14(&self) -> u64 {
+        self.r14
+    }
+    fn r13(&self) -> u64 {
+        self.r13
+    }
+    fn r12(&self) -> u64 {
+        self.r12
+    }
+    fn rbp(&self) -> u64 {
+        self.rbp
+    }
+    fn rbx(&self) -> u64 {
+        self.rbx
+    }
+    fn r11(&self) -> u64 {
+        self.r11
+    }
+    fn r10(&self) -> u64 {
+        self.r10
+    }
+    fn r9(&self) -> u64 {
+        self.r9
+    }
+    fn r8(&self) -> u64 {
+        self.r8
+    }
+    fn rax(&self) -> u64 {
+        self.rax
+    }
+    fn rcx(&self) -> u64 {
+        self.rcx
+    }
+    fn rdx(&self) -> u64 {
+        self.rdx
+    }
+    fn rsi(&self) -> u64 {
+        self.rsi
+    }
+    fn rdi(&self) -> u64 {
+        self.rdi
+    }
+    fn rip(&self) -> u64 {
+        self.rip
+    }
+    fn cs(&self) -> u64 {
+        self.cs
+    }
+    fn rflags(&self) -> u64 {
+        self.eflags
+    }
+    fn rsp(&self) -> u64 {
+        self.rsp
+    }
+    fn ss(&self) -> u64 {
+        self.ss
+    }
+    fn ds(&self) -> u64 {
+        self.ds
+    }
+    fn es(&self) -> u64 {
+        self.es
+    }
+    fn fs(&self) -> u64 {
+        self.fs
+    }
+    fn gs(&self) -> u64 {
+        self.gs
+    }
+
+    fn set_r15(&mut self, value: u64) {
+        self.r15 = value;
+    }
+    fn set_r14(&mut self, value: u64) {
+        self.r14 = value;
+    }
+    fn set_r13(&mut self, value: u64) {
+        self.r13 = value;
+    }
+    fn set_r12(&mut self, value: u64) {
+        self.r12 = value;
+    }
+    fn set_rbp(&mut self, value: u64) {
+        self.rbp = value;
+    }
+    fn set_rbx(&mut self, value: u64) {
+        self.rbx = value;
+    }
+    fn set_r11(&mut self, value: u64) {
+        self.r11 = value;
+    }
+    fn set_r10(&mut self, value: u64) {
+        self.r10 = value;
+    }
+    fn set_r9(&mut self, value: u64) {
+        self.r9 = value;
+    }
+    fn set_r8(&mut self, value: u64) {
+        self.r8 = value;
+    }
+    fn set_rax(&mut self, value: u64) {
+        self.rax = value;
+    }
+    fn set_rcx(&mut self, value: u64) {
+        self.rcx = value;
+    }
+    fn set_rdx(&mut self, value: u64) {
+        self.rdx = value;
+    }
+    fn set_rsi(&mut self, value: u64) {
+        self.rsi = value;
+    }
+    fn set_rdi(&mut self, value: u64) {
+        self.rdi = value;
+    }
+    fn set_rip(&mut self, value: u64) {
+        self.rip = value;
+    }
+    fn set_cs(&mut self, value: u64) {
+        self.cs = value;
+    }
+    fn set_rflags(&mut self, value: u64) {
+        self.eflags = value;
+    }
+    fn set_rsp(&mut self, value: u64) {
+        self.rsp = value;
+    }
+    fn set_ss(&mut self, value: u64) {
+        self.ss = value;
+    }
+    fn set_ds(&mut self, value: u64) {
+        self.ds = value;
+    }
+    fn set_es(&mut self, value: u64) {
+        self.es = value;
+    }
+    fn set_fs(&mut self, value: u64) {
+        self.fs = value;
+    }
+    fn set_gs(&mut self, value: u64) {
+        self.gs = value;
+    }
+}

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,6 +2,7 @@ use crate::{
     util::{MemoryMap, Permissions},
     Pid, Registers,
 };
+use nix::sys::uio::{process_vm_readv, process_vm_writev, IoVec, RemoteIoVec};
 use procfs::process::{MMapPath, MemoryMap as ProcMMap, Process};
 use procfs::ProcResult;
 
@@ -18,7 +19,8 @@ impl From<ProcMMap> for MemoryMap {
 
         MemoryMap {
             start,
-            end,
+            // make end address inclusive
+            end: end - 1,
             offset: mmap.offset,
             permissions: Permissions::from(mmap.perms.as_ref()),
             filepath,
@@ -38,6 +40,7 @@ impl From<&str> for Permissions {
     }
 }
 
+/// Get memory mappings of process identified by `pid`.
 pub fn get_memory_maps(pid: Pid) -> ProcResult<Vec<MemoryMap>> {
     Ok(Process::new(pid.as_raw())?
         .maps()?
@@ -46,9 +49,8 @@ pub fn get_memory_maps(pid: Pid) -> ProcResult<Vec<MemoryMap>> {
         .collect())
 }
 
+/// Read data from remote process identified by `pid`.
 pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize> {
-    use nix::sys::uio::{process_vm_readv, IoVec, RemoteIoVec};
-
     let len = data.len();
     let local_iov = IoVec::from_mut_slice(data);
     let remote_iov = RemoteIoVec { base: address, len };
@@ -56,149 +58,206 @@ pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize
     process_vm_readv(pid, &[local_iov], &[remote_iov])
 }
 
+/// Write data to remote process identified by `pid`.
+pub fn write_data(pid: Pid, address: usize, data: &[u8]) -> nix::Result<usize> {
+    let len = data.len();
+    let local_iov = IoVec::from_slice(data);
+    let remote_iov = RemoteIoVec { base: address, len };
+
+    process_vm_writev(pid, &[local_iov], &[remote_iov])
+}
+
 impl Registers for nix::libc::user_regs_struct {
+    #[inline]
     fn r15(&self) -> u64 {
         self.r15
     }
+    #[inline]
     fn r14(&self) -> u64 {
         self.r14
     }
+    #[inline]
     fn r13(&self) -> u64 {
         self.r13
     }
+    #[inline]
     fn r12(&self) -> u64 {
         self.r12
     }
+    #[inline]
     fn rbp(&self) -> u64 {
         self.rbp
     }
+    #[inline]
     fn rbx(&self) -> u64 {
         self.rbx
     }
+    #[inline]
     fn r11(&self) -> u64 {
         self.r11
     }
+    #[inline]
     fn r10(&self) -> u64 {
         self.r10
     }
+    #[inline]
     fn r9(&self) -> u64 {
         self.r9
     }
+    #[inline]
     fn r8(&self) -> u64 {
         self.r8
     }
+    #[inline]
     fn rax(&self) -> u64 {
         self.rax
     }
+    #[inline]
     fn rcx(&self) -> u64 {
         self.rcx
     }
+    #[inline]
     fn rdx(&self) -> u64 {
         self.rdx
     }
+    #[inline]
     fn rsi(&self) -> u64 {
         self.rsi
     }
+    #[inline]
     fn rdi(&self) -> u64 {
         self.rdi
     }
+    #[inline]
     fn rip(&self) -> u64 {
         self.rip
     }
+    #[inline]
     fn cs(&self) -> u64 {
         self.cs
     }
+    #[inline]
     fn rflags(&self) -> u64 {
         self.eflags
     }
+    #[inline]
     fn rsp(&self) -> u64 {
         self.rsp
     }
+    #[inline]
     fn ss(&self) -> u64 {
         self.ss
     }
+    #[inline]
     fn ds(&self) -> u64 {
         self.ds
     }
+    #[inline]
     fn es(&self) -> u64 {
         self.es
     }
+    #[inline]
     fn fs(&self) -> u64 {
         self.fs
     }
+    #[inline]
     fn gs(&self) -> u64 {
         self.gs
     }
 
+    #[inline]
     fn set_r15(&mut self, value: u64) {
         self.r15 = value;
     }
+    #[inline]
     fn set_r14(&mut self, value: u64) {
         self.r14 = value;
     }
+    #[inline]
     fn set_r13(&mut self, value: u64) {
         self.r13 = value;
     }
+    #[inline]
     fn set_r12(&mut self, value: u64) {
         self.r12 = value;
     }
+    #[inline]
     fn set_rbp(&mut self, value: u64) {
         self.rbp = value;
     }
+    #[inline]
     fn set_rbx(&mut self, value: u64) {
         self.rbx = value;
     }
+    #[inline]
     fn set_r11(&mut self, value: u64) {
         self.r11 = value;
     }
+    #[inline]
     fn set_r10(&mut self, value: u64) {
         self.r10 = value;
     }
+    #[inline]
     fn set_r9(&mut self, value: u64) {
         self.r9 = value;
     }
+    #[inline]
     fn set_r8(&mut self, value: u64) {
         self.r8 = value;
     }
+    #[inline]
     fn set_rax(&mut self, value: u64) {
         self.rax = value;
     }
+    #[inline]
     fn set_rcx(&mut self, value: u64) {
         self.rcx = value;
     }
+    #[inline]
     fn set_rdx(&mut self, value: u64) {
         self.rdx = value;
     }
+    #[inline]
     fn set_rsi(&mut self, value: u64) {
         self.rsi = value;
     }
+    #[inline]
     fn set_rdi(&mut self, value: u64) {
         self.rdi = value;
     }
+    #[inline]
     fn set_rip(&mut self, value: u64) {
         self.rip = value;
     }
+    #[inline]
     fn set_cs(&mut self, value: u64) {
         self.cs = value;
     }
+    #[inline]
     fn set_rflags(&mut self, value: u64) {
         self.eflags = value;
     }
+    #[inline]
     fn set_rsp(&mut self, value: u64) {
         self.rsp = value;
     }
+    #[inline]
     fn set_ss(&mut self, value: u64) {
         self.ss = value;
     }
+    #[inline]
     fn set_ds(&mut self, value: u64) {
         self.ds = value;
     }
+    #[inline]
     fn set_es(&mut self, value: u64) {
         self.es = value;
     }
+    #[inline]
     fn set_fs(&mut self, value: u64) {
         self.fs = value;
     }
+    #[inline]
     fn set_gs(&mut self, value: u64) {
         self.gs = value;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,28 @@
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::BufReader;
+use crate::{Pid, Registers};
+use std::path::PathBuf;
 
-use crate::Pid;
+#[cfg(any(target_os = "android", target_os = "linux"))]
+pub use crate::linux::{get_memory_maps, read_data};
+
+#[cfg(target_os = "freebsd")]
+pub use crate::freebsd::{get_memory_maps, read_data};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MemoryMap {
+    pub start: u64,
+    pub end: u64,
+    pub offset: u64,
+    pub permissions: Permissions,
+    pub filepath: Option<PathBuf>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Permissions {
+    pub read: bool,
+    pub write: bool,
+    pub execute: bool,
+    pub copy: bool,
+}
 
 pub fn read_string_max_size(pid: Pid, address: usize, max_size: usize) -> nix::Result<String> {
     let mut data = vec![0u8; max_size];
@@ -21,96 +41,53 @@ pub fn read_string(pid: Pid, address: usize, count: usize) -> nix::Result<String
     Ok(String::from_utf8(data).unwrap())
 }
 
-pub fn read_data(pid: Pid, address: usize, data: &mut [u8]) -> nix::Result<usize> {
-    use nix::sys::uio::{process_vm_readv, IoVec, RemoteIoVec};
-
-    let len = data.len();
-    let local_iov = IoVec::from_mut_slice(data);
-    let remote_iov = RemoteIoVec { base: address, len };
-
-    process_vm_readv(pid, &[local_iov], &[remote_iov])
-}
-
-pub fn show_registers(regs: &nix::libc::user_regs_struct) {
+pub fn show_registers<R: Registers>(regs: &R) {
     println!(
         "R15      {:016x}    R14     {:016x}    R13    {:016x}",
-        regs.r15, regs.r14, regs.r13
+        regs.r15(),
+        regs.r14(),
+        regs.r13()
     );
     println!(
         "R12      {:016x}    RBP     {:016x}    RBX    {:016x}",
-        regs.r12, regs.rbp, regs.rbx
+        regs.r12(),
+        regs.rbp(),
+        regs.rbx()
     );
     println!(
         "R11      {:016x}    R10     {:016x}    R9     {:016x}",
-        regs.r11, regs.r10, regs.r9
+        regs.r11(),
+        regs.r10(),
+        regs.r9()
     );
     println!(
         "R8       {:016x}    RAX     {:016x}    RCX    {:016x}",
-        regs.r8, regs.rax, regs.rcx
+        regs.r8(),
+        regs.rax(),
+        regs.rcx()
     );
     println!(
         "RDX      {:016x}    RSI     {:016x}    RDI    {:016x}",
-        regs.rdx, regs.rsi, regs.rdi
+        regs.rdx(),
+        regs.rsi(),
+        regs.rdi()
     );
     println!(
-        "ORIG_RAX {:016x}    RIP     {:016x}    CS     {:016x}",
-        regs.orig_rax, regs.rip, regs.cs
+        "RIP     {:016x}    CS     {:016x}      EFLAGS   {:016x}",
+        regs.rip(),
+        regs.cs(),
+        regs.rflags()
     );
     println!(
-        "EFLAGS   {:016x}    RSP     {:016x}    SS     {:016x}",
-        regs.eflags, regs.rsp, regs.ss
-    );
-    println!(
-        "FS_BASE  {:016x}    GS_BASE {:016x}    DS     {:016x}",
-        regs.fs_base, regs.gs_base, regs.ds
+        "RSP     {:016x}    SS     {:016x}      DS     {:016x}",
+        regs.rsp(),
+        regs.ss(),
+        regs.ds()
     );
     println!(
         "ES       {:016x}    FS      {:016x}    GS     {:016x}",
-        regs.es, regs.fs, regs.gs
+        regs.es(),
+        regs.fs(),
+        regs.gs()
     );
-}
-
-pub struct MemoryMap {
-    pub offset: usize,
-    pub size: usize,
-    pub file_offset: usize,
-    pub perm: String, // TODO: rwx
-    pub path: String,
-}
-
-pub fn read_memory_maps(pid: Pid) -> Vec<MemoryMap> {
-    let path = format!("/proc/{}/maps", pid);
-    let mut maps = Vec::new();
-
-    let f = File::open(&path).unwrap();
-    let f = BufReader::new(f);
-
-    for line in f.lines() {
-        let line = line.unwrap();
-        let v: Vec<&str> = line.split_whitespace().collect();
-
-        assert!(v.len() == 5 || v.len() == 6);
-
-        if v.len() == 6 {
-            let addr: Vec<usize> = v[0]
-                .split('-')
-                .map(|x| usize::from_str_radix(x, 16).unwrap())
-                .collect();
-            assert_eq!(addr.len(), 2);
-
-            let map = MemoryMap {
-                offset: addr[0],
-                size: addr[1] - addr[0],
-                file_offset: usize::from_str_radix(v[2], 16).unwrap(),
-                perm: v[1].to_owned(),
-                path: v[5].to_owned(),
-            };
-
-            maps.push(map);
-        } else if v.len() == 5 {
-            // TODO(bostjan)
-        }
-    }
-
-    maps
 }


### PR DESCRIPTION
I finally came around to do a bit more polishing because I needed FreeBSD support.

This PR adds:
- some abstractions to allow FreeBSD support
- FreeBSD support
- "cleaner" memory map implementation
- basic documentation

P.S.:
You should also update the crate on crates.io, it's still on `0.1.0`.