### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptracer"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     "Bostjan Vesnicer <bostjan.vesnicer@gmail.com>",
     "Simon Wörner <git@simon-woerner.de>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [dependencies]
 libc = "^0.2.72"
-nix = "^0.17"
+nix = "^0.23"
 cfg-if = "^0.1"
 log = "^0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "^0.1"
 log = "^0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-procfs = "^0.7"
+procfs = { version = "^0.11", default-features = false }
 
 [dev-dependencies]
 goblin = { version = "^0.1.3", default_features=false, features=["std", "endian_fd", "elf32", "elf64"]}


### PR DESCRIPTION
while `ptracer` is likely not affected it still shows up in `cargo audit`.

see [RUSTSEC-2021-0119](https://github.com/rustsec/advisory-db/blob/main/crates/nix/RUSTSEC-2021-0119.md) and [RUSTSEC-2020-0071](https://github.com/rustsec/advisory-db/blob/main/crates/time/RUSTSEC-2020-0071.md)